### PR TITLE
Fix some typos

### DIFF
--- a/DC-SAP-EIC
+++ b/DC-SAP-EIC
@@ -1,4 +1,4 @@
- MAIN="SAP-EIC-Main.adoc"
+MAIN="SAP-EIC-Main.adoc"
 
 ADOC_TYPE="article"
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Thank you for contributing to this repo. Please adhere to the following guidelin
 
 To contribute to the documentation, you need to write DocBook.
 
-* You can learn about DocBook syntax at http://docbook.org/tdg5/en/html .
+* You can learn about DocBook syntax at http://docbook.org/tdg5/en/html.
 * SUSE documents are generally built with DAPS (package `daps`) and the
   SUSE XSL Stylesheets (package `suse-xsl-stylesheets`). Ideally, you should
   get these from the repository `Documentation:Tools`. However, slightly
@@ -89,7 +89,7 @@ Learn more at https://opensuse.github.io/daps
 | DC-CaaSP3-DataHub2 | ext | Container | https://documentation.suse.com/suse-caasp/4.0/, https://documentation.suse.com/sles-sap-12/, https://documentation.suse.com/sles-sap-15/ |
 | DC-SAP_HA740_SetupGuide_AWS | ext | SAP | https://documentation.suse.com/sles-sap-12/ |
 | DC-SAP_NW740_SLE12_SetupGuide | ext | SAP | https://documentation.suse.com/sles-sap-12/ |
-|D C-SAP_NW740_SLE15_SetupGuide | ext | SAP | https://documentation.suse.com/sles-sap-15/ |
+| DC-SAP_NW740_SLE15_SetupGuide | ext | SAP | https://documentation.suse.com/sles-sap-15/ |
 | DC-SAP_S4HA10_SetupGuide-SLE12 | ext | SAP | https://documentation.suse.com/sles-sap-12/ |
 | DC-SAP_S4HA10_SetupGuide-SLE15 | ext | SAP | https://documentation.suse.com/sles-sap-15/ |
 | DC-SBP-AMD-EPYC-2-SLES15SP1 | ext | ELS | https://documentation.suse.com/sles-15/ |

--- a/adoc/SAP-EIC-Main.adoc
+++ b/adoc/SAP-EIC-Main.adoc
@@ -70,7 +70,7 @@ The support matrix below shows which versions of the given software we'll use in
 
 IMPORTANT: If you want to use different versions of {slem}, {rancher}, {rke} or {lh}, make sure to check the support matrix for the related solutions you want to use:
 https://www.suse.com/suse-rancher/support-matrix/all-supported-versions/ +
-For {redis} and {pg}, make sure to pick versions compatible to {eic}, which can be found in https://me.sap.com/notes/3247839 . +
+For {redis} and {pg}, make sure to pick versions compatible to {eic}, which can be found in https://me.sap.com/notes/3247839. +
 Other versions of {metallb} or {cm} can be used but may have not been tested. 
 
 ++++
@@ -135,7 +135,7 @@ Starting with installing the operating system of each machine or Kubernetes node
 ++++
 
 == Installing {slem} {slem_version}
-There are several ways to install {slem} {slem_version}. For this best practice guide, we use the installation method via graphical installer. But in cloud-native deployments it is highly recommended to use Infrastructur- as-Code technologies to fully automate the deployment and lifecycle processes. 
+There are several ways to install {slem} {slem_version}. For this best practice guide, we use the installation method via graphical installer. But in cloud-native deployments it is highly recommended to use Infrastructure-as-Code technologies to fully automate the deployment and lifecycle processes. 
 
 include::SAP-EIC-SLEMicro.adoc[SLEMicro]
 

--- a/adoc/SAP-EIC-Metallb.adoc
+++ b/adoc/SAP-EIC-Metallb.adoc
@@ -2,7 +2,7 @@
 
 There are multiple ways to install the {metallb} software. In this guide, we will cover how to install {metallb} using `kubectl` or Helm.
 A complete overview and more details about {metallb} can be found on the 
-link:https://metallb.universe.tf/[official website for {metallb}]
+link:https://metallb.universe.tf/[official website for {metallb}].
 
 === Prerequisites
 
@@ -20,7 +20,7 @@ $ kubectl create namespace metallb
 ----
 
 [#metalIPS]
-Instructions how to create the *imagePullSecret* can be found in xref:SAP-EIC-ImagePullSecrets.adoc#imagePullSecret[]
+Instructions how to create the *imagePullSecret* can be found in xref:SAP-EIC-ImagePullSecrets.adoc#imagePullSecret[].
 
 ++++
 <?pdfpagebreak?>
@@ -29,7 +29,7 @@ Instructions how to create the *imagePullSecret* can be found in xref:SAP-EIC-Im
 === Installation of {metallb}
 
 [#metalLIR]
-Before you can install the application, you need to login into the registry. You can find the instruction in xref:SAP-EIC-LoginRegistryApplicationCollection.adoc#LoginApplicationCollection[]
+Before you can install the application, you need to login into the registry. You can find the instruction in xref:SAP-EIC-LoginRegistryApplicationCollection.adoc#LoginApplicationCollection[].
 
 To install {metallb} run the following lines in your terminal:
 

--- a/adoc/SAP-EIC-PostgreSQL.adoc
+++ b/adoc/SAP-EIC-PostgreSQL.adoc
@@ -32,7 +32,7 @@ Second, create the Kubernetes secret with the certificates. You will find an exa
 
 === Installing the application
 [#pgLIR]
-Before you can install the application, you need to log in to the registry. You can find the instruction in xref:SAP-EIC-LoginRegistryApplicationCollection.adoc#LoginApplicationCollection[]
+Before you can install the application, you need to log in to the registry. You can find the instruction in xref:SAP-EIC-LoginRegistryApplicationCollection.adoc#LoginApplicationCollection[].
 
 Create a file *values.yaml* which holds some configurations for the {pg} Helm chart.
 The configuration may look like:

--- a/adoc/SAP-EIC-Redis.adoc
+++ b/adoc/SAP-EIC-Redis.adoc
@@ -18,7 +18,7 @@ instead of link:https://redis.io/docs/management/scaling/[{redis} Cluster].
 == Deploying Redis
 
 Although {redis} is available for deployment using the {rancher} Apps, we recommend using the {rac}.
-The {redis} chart can be found at https://apps.rancher.io/applications/redis .
+The {redis} chart can be found at https://apps.rancher.io/applications/redis.
 
 ++++
 <?pdfpagebreak?>
@@ -36,13 +36,13 @@ $ kubectl create namespace redis
 ----
 
 [#redisIPS]
-Instructions how to create the *imagePullSecret* can be found in xref:SAP-EIC-ImagePullSecrets.adoc#imagePullSecret[]
+Instructions how to create the *imagePullSecret* can be found in xref:SAP-EIC-ImagePullSecrets.adoc#imagePullSecret[].
 
 
-If you want to use self-signed certificates, you can find instructions how to create such in xref:SAP-EIC-Main.adoc#selfSignedCertificates[]
+If you want to use self-signed certificates, you can find instructions how to create such in xref:SAP-EIC-Main.adoc#selfSignedCertificates[].
 
 [#redisLIR]
-Before you can install the application, you need to log in to the registry. You can find the instruction in xref:SAP-EIC-LoginRegistryApplicationCollection.adoc#LoginApplicationCollection[]
+Before you can install the application, you need to log in to the registry. You can find the instruction in xref:SAP-EIC-LoginRegistryApplicationCollection.adoc#LoginApplicationCollection[].
 
 
 Create a file *values.yaml* which holds some configurations for the {redis} Helm chart.

--- a/adoc/SAP-EIC-SLEMicro.adoc
+++ b/adoc/SAP-EIC-SLEMicro.adoc
@@ -19,7 +19,7 @@ TIP: If you have already set up all machines and the operating system, skip this
 === Registering your system
 
 To get your system up-to-date, you need to register it with SUSE Manager, an RMT server, or directly with the SCC Portal. 
-Find the registrationprocess with a direct connection to SCC describedin the instructions below. For more information, see the {slem} documentation.
+Find the registration process with a direct connection to SCC describedin the instructions below. For more information, see the {slem} documentation.
 
 Registering the system is possible from the command line using the `transactional-update register` command. 
 For information that goes beyond the scope of this section, refer to the inline documentation with *SUSEConnect --help*. 
@@ -61,7 +61,7 @@ $ systemctl --now disable transactional-update.timer
 ----
 
 === Preparing for {lh}
-For {lh} you need to do some preparation steps. First, install some addional packages on all worker nodes. Then attach a second disk to the worker nodes, create a file system ontop of it and mount it to the Longhorn default location. The size of the second disk depends on your use case. 
+For {lh} you need to do some preparation steps. First, install some additional packages on all worker nodes. Then attach a second disk to the worker nodes, create a file system ontop of it and mount it to the Longhorn default location. The size of the second disk depends on your use case. 
 
 Install some packages as a requirement for longhorn and Logical Volume Management for adding a file system to Longhorn.
 [source, bash]
@@ -84,7 +84,7 @@ $ systemctl enable iscsid  --now
 
 ==== Creating file system for {lh}
 
-The next step is to create a new logical volume with the Logical Volume Managemen. 
+The next step is to create a new logical volume with the Logical Volume Management. 
 
 First, you need to create a new physical volume. In our case the second disk is called _vdb_. Use this as longhorn volume.
 [source, bash]

--- a/adoc/SAP-Rancher-RKE2-Installation.adoc
+++ b/adoc/SAP-Rancher-RKE2-Installation.adoc
@@ -36,13 +36,13 @@ After you clicked *Create*, you should see a screen like this:
 image::SAP-Rancher-Create-Register.png[title=Rancher create registration,scaledwidth=99%]
 
 Now, in a first step, select the roles your node(s) should receive.
-A common high avaiability setup holds:
+A common high availability setup holds:
 
 * 3 x etcd / controll plane nodes
 * 3 x worker nodes
 
 The next step is to copy the registration command to the target machines' shell and execute it.
-If your {rancher} instance holds a self-signed certifcate, make sure to activate the text bar holding the registration command in the check box below .
+If your {rancher} instance holds a self-signed certifcate, make sure to activate the text bar holding the registration command in the check box below.
 
 You can run the command on all nodes in parallel. You do not need to wait until a single node is down.
 When all machines are registered, you can see the cluster status at the top, changing from "updating" to "active".

--- a/adoc/SAPDI3-Longhorn.adoc
+++ b/adoc/SAPDI3-Longhorn.adoc
@@ -19,7 +19,7 @@ all nodes must have the `open-iscsi` package installed, and the ISCSI daemon nee
 ----
 endif::[]
 
-To esure a node is prepared for {lh}, you can use the following script to check:
+To ensure a node is prepared for {lh}, you can use the following script to check:
 ----
 $ curl -sSfL https://raw.githubusercontent.com/longhorn/longhorn/v1.6.2/scripts/environment_check.sh | bash
 ----

--- a/adoc/SAPDI3-Rancher.adoc
+++ b/adoc/SAPDI3-Rancher.adoc
@@ -185,7 +185,7 @@ Do not forget to restart or reload `haproxy` if any changes are made to the hapr
 To install RKE2, the script provided at https://get.rke2.io can be used as follows:
 [source, bash]
 ----
-$ curl -sfL https://get.rke2.io | INSTALL_RKE2_VERSION=v1.28.13-rke2r1 sh
+$ curl -sfL https://get.rke2.io | INSTALL_RKE2_VERSION=v1.28.13+rke2r1 sh
 ----
 
 For HA setups, it is necessary to create RKE2 cluster configuration files in advance.
@@ -275,7 +275,7 @@ How to create the *imagePullSecret* is described in the xref:SAP-EIC-ImagePullSe
 
 ifdef::eic[]
 [#rancherLIR]
-Before you can install the application, you need to login into the registry. You can find the instruction in xref:SAP-EIC-LoginRegistryApplicationCollection.adoc#LoginApplicationCollection[]
+Before you can install the application, you need to login into the registry. You can find the instruction in xref:SAP-EIC-LoginRegistryApplicationCollection.adoc#LoginApplicationCollection[].
 endif::[]
 
 ifndef::eic[]


### PR DESCRIPTION
After following the EIC guide I found some typos and got an error:

```
localhost:~ # curl -sfL https://get.rke2.io | INSTALL_RKE2_VERSION=v1.28.13-rke2r1 sh
[WARN]  /usr/local is read-only or a mount point; installing to /opt/rke2
[INFO]  using v1.28.13-rke2r1 as release
[INFO]  downloading checksums at https://github.com/rancher/rke2/releases/download/v1.28.13-rke2r1/sha256sum-amd64.txt
curl: (22) The requested URL returned error: 404
```

That is solved by replacing "-" with "+".